### PR TITLE
Use backwards lookup on ping/loss

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,12 +59,13 @@ class StatusParser():
         return re.findall(self.patterns["server"]["max_player_count"], rcon)[0]
 
     def get_player_info(self, player):
+        # Player ping/loss use backwards lookups for when there is a number surrounded by spaces in a player's name
         player_id             = re.findall(self.patterns["players"]["id"], player)[0]
         player_name           = re.findall(self.patterns["players"]["name"], player)[0]
         player_steam_id       = re.findall(self.patterns["players"]["steam_id"], player)[0]
         player_time_connected = re.findall(self.patterns["players"]["time_connected"], player)[0]
-        player_ping           = re.findall(self.patterns["players"]["ping/loss"], player)[0]
-        player_loss           = re.findall(self.patterns["players"]["ping/loss"], player)[1]
+        player_ping           = re.findall(self.patterns["players"]["ping/loss"], player)[-2]
+        player_loss           = re.findall(self.patterns["players"]["ping/loss"], player)[-1]
         player_ip             = re.findall(self.patterns["players"]["ip"], player)[0]
         player_state          = re.findall(self.patterns["players"]["state"], player)[0]
 


### PR DESCRIPTION
Should resolve the incorrectly reported ping when players have numbers surrounded by spaces in their name.

The way that the parsing is currently implemented assumes that the first number surrounded by spaces will always be the ping, and the second will always be the loss. When a player has a number surrounded by spaces in their name (e.g. `I ate 1001 cookies`) that assumption is obviously invalidated.

In Python, you can access the last item in a list using `list[-1]`, the second last with `list[-2]`, and so on. Example `status` player line: `#     30 "THERE ARE 999 BABOONS"              STEAM_0:1:15454545  54:35      127    0 active 12.345.67.890:27005`

Since it is guaranteed that there are no other numbers surrounded by spaces going _backwards_, we know that the `ping/loss` pattern will have the loss as its last entry, and the ping as its second to last.